### PR TITLE
chore(dev-deps): Remove phpunit

### DIFF
--- a/wptest/composer.json
+++ b/wptest/composer.json
@@ -1,6 +1,5 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "yoast/phpunit-polyfills": "^1.0"
     },
     "config": {

--- a/wptest/composer.lock
+++ b/wptest/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e4612fc36bbec8874b46a44e1071933",
+    "content-hash": "ad9398fffd6874eab42bae57fe57db44",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
```
 composer why phpunit/phpunit
__root__                dev-master requires (for development) phpunit/phpunit (^9.5)                                               
yoast/phpunit-polyfills 1.0.4      requires                   phpunit/phpunit (^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0) 
```

`yoast/phpunit-polyfills` depends on `phpunut/phpunit`; we, therefore, can remove it from `composer.lock` and avoid unnecessary pull requests to update it.
